### PR TITLE
feat: vendor artifacts — source packages from vendor release feeds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,10 +13,6 @@ RUN set -eu; \
 
 # ── RPM download stages (parallel, each downloads from one external repo) ────
 
-FROM base AS dl-code
-ARG CACHE_EPOCH_CODE=0
-RUN bkt-build download-rpms code
-
 FROM base AS dl-microsoft-edge
 ARG CACHE_EPOCH_MICROSOFT_EDGE=0
 RUN bkt-build download-rpms microsoft-edge
@@ -26,10 +22,6 @@ ARG CACHE_EPOCH_1PASSWORD=0
 RUN bkt-build download-rpms 1password
 
 # ── RPM install stages (per-package extraction with /opt relocation) ─────────
-
-FROM base AS install-code
-COPY --from=dl-code /rpms/ /tmp/rpms/
-RUN rpm -i --nodb --noscripts --nodeps /tmp/rpms/*.rpm && rm -rf /tmp/rpms
 
 FROM base AS install-microsoft-edge
 COPY --from=dl-microsoft-edge /rpms/ /tmp/rpms/
@@ -238,10 +230,9 @@ FROM base AS image
 # === END KERNEL_ARGUMENTS ===
 
 # Import installed files from install-* stages (no --link to avoid xattrs hardlink limit)
-COPY --from=install-code / /
 COPY --from=install-microsoft-edge / /
 COPY --from=install-bundled / /
-COPY --from=vendor-code / /
+COPY --from=vendor-code /usr/ /usr/
 
 # === SYSTEM_PACKAGES (managed by bkt) ===
 RUN dnf install -y \
@@ -276,17 +267,15 @@ RUN printf '%s\n' \
     >/usr/lib/tmpfiles.d/bootc-opt.conf
 
 # Finalize RPM database for external packages
-COPY --from=dl-code /rpms/ /tmp/rpms-code/
 COPY --from=dl-microsoft-edge /rpms/ /tmp/rpms-microsoft-edge/
 COPY --from=dl-1password /rpms/ /tmp/rpms-1password/
 COPY --from=vendor-code /rpms/ /tmp/rpms-vendor-code/
 RUN set -eu; \
-    rpm -i --justdb --nodeps /tmp/rpms-code/*.rpm; \
     rpm -i --justdb --nodeps /tmp/rpms-microsoft-edge/*.rpm; \
     rpm -i --justdb --nodeps /tmp/rpms-1password/*.rpm; \
     rpm -i --justdb --nodeps /tmp/rpms-vendor-code/*.rpm; \
     ldconfig; \
-    rm -rf /tmp/rpms-code /tmp/rpms-microsoft-edge /tmp/rpms-1password /tmp/rpms-vendor-code
+    rm -rf /tmp/rpms-microsoft-edge /tmp/rpms-1password /tmp/rpms-vendor-code
 
 # Clean up build-time artifacts (no longer needed after package install)
 RUN rm -rf /tmp/external-repos.json /usr/bin/bkt-build

--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ COPY --from=install-1password / /
 # ── Vendor artifact stages (parallel, each fetches one resolved artifact) ────
 
 FROM base AS vendor-code
-COPY .cache/bkt/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json
+COPY build/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json
 RUN bkt-build install-vendor-artifact code
 
 # ── Upstream fetch stages (parallel, each installs one upstream entry) ───────

--- a/Containerfile
+++ b/Containerfile
@@ -52,6 +52,12 @@ RUN set -eu; \
 FROM scratch AS install-bundled
 COPY --from=install-1password / /
 
+# ── Vendor artifact stages (parallel, each fetches one resolved artifact) ────
+
+FROM base AS vendor-code
+COPY .cache/bkt/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json
+RUN bkt-build install-vendor-artifact code
+
 # ── Upstream fetch stages (parallel, each installs one upstream entry) ───────
 
 FROM base AS fetch-starship
@@ -235,6 +241,7 @@ FROM base AS image
 COPY --from=install-code / /
 COPY --from=install-microsoft-edge / /
 COPY --from=install-bundled / /
+COPY --from=vendor-code / /
 
 # === SYSTEM_PACKAGES (managed by bkt) ===
 RUN dnf install -y \
@@ -272,12 +279,14 @@ RUN printf '%s\n' \
 COPY --from=dl-code /rpms/ /tmp/rpms-code/
 COPY --from=dl-microsoft-edge /rpms/ /tmp/rpms-microsoft-edge/
 COPY --from=dl-1password /rpms/ /tmp/rpms-1password/
+COPY --from=vendor-code /rpms/ /tmp/rpms-vendor-code/
 RUN set -eu; \
     rpm -i --justdb --nodeps /tmp/rpms-code/*.rpm; \
     rpm -i --justdb --nodeps /tmp/rpms-microsoft-edge/*.rpm; \
     rpm -i --justdb --nodeps /tmp/rpms-1password/*.rpm; \
+    rpm -i --justdb --nodeps /tmp/rpms-vendor-code/*.rpm; \
     ldconfig; \
-    rm -rf /tmp/rpms-code /tmp/rpms-microsoft-edge /tmp/rpms-1password
+    rm -rf /tmp/rpms-code /tmp/rpms-microsoft-edge /tmp/rpms-1password /tmp/rpms-vendor-code
 
 # Clean up build-time artifacts (no longer needed after package install)
 RUN rm -rf /tmp/external-repos.json /usr/bin/bkt-build

--- a/bkt-build/Cargo.lock
+++ b/bkt-build/Cargo.lock
@@ -114,7 +114,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bkt-common",
+ "chrono",
  "clap",
+ "serde_json",
 ]
 
 [[package]]

--- a/bkt-build/Cargo.toml
+++ b/bkt-build/Cargo.toml
@@ -10,4 +10,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 bkt-common = { path = "../bkt-common", features = ["http"] }
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+serde_json = "1"

--- a/bkt-build/src/main.rs
+++ b/bkt-build/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 mod fetch;
 mod repos;
+mod vendor_artifacts;
 
 #[derive(Parser)]
 #[command(
@@ -39,6 +40,26 @@ enum Commands {
         #[arg(long, default_value = "/tmp/external-repos.json")]
         manifest: PathBuf,
     },
+    /// Resolve vendor artifacts from their feed URLs.
+    /// Runs from the repo checkout (CI), so paths are relative to the repo root.
+    ResolveVendorArtifacts {
+        /// Path to vendor-artifacts.json manifest
+        #[arg(long, default_value = "manifests/vendor-artifacts.json")]
+        manifest: PathBuf,
+        /// Output path for resolved manifest
+        #[arg(long, default_value = ".cache/bkt/vendor-artifacts.resolved.json")]
+        output: PathBuf,
+    },
+    /// Install a resolved vendor artifact by name.
+    /// Runs inside the container build, where the resolved manifest has been
+    /// COPY'd to /tmp/.
+    InstallVendorArtifact {
+        /// Artifact name
+        name: String,
+        /// Path to resolved vendor artifacts manifest
+        #[arg(long, default_value = "/tmp/vendor-artifacts.resolved.json")]
+        resolved: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -47,5 +68,11 @@ fn main() -> Result<()> {
         Commands::Fetch { name, manifest } => fetch::run(&name, &manifest),
         Commands::SetupRepos { manifest } => repos::setup_repos(&manifest),
         Commands::DownloadRpms { repo, manifest } => repos::download_rpms(&repo, &manifest),
+        Commands::ResolveVendorArtifacts { manifest, output } => {
+            vendor_artifacts::resolve(&manifest, &output)
+        }
+        Commands::InstallVendorArtifact { name, resolved } => {
+            vendor_artifacts::install(&name, &resolved)
+        }
     }
 }

--- a/bkt-build/src/main.rs
+++ b/bkt-build/src/main.rs
@@ -47,7 +47,7 @@ enum Commands {
         #[arg(long, default_value = "manifests/vendor-artifacts.json")]
         manifest: PathBuf,
         /// Output path for resolved manifest
-        #[arg(long, default_value = ".cache/bkt/vendor-artifacts.resolved.json")]
+        #[arg(long, default_value = "build/vendor-artifacts.resolved.json")]
         output: PathBuf,
     },
     /// Install a resolved vendor artifact by name.

--- a/bkt-build/src/vendor_artifacts.rs
+++ b/bkt-build/src/vendor_artifacts.rs
@@ -7,7 +7,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use bkt_common::checksum::sha256_hex;
 use bkt_common::http;
 use bkt_common::manifest::{
-    ResolvedVendorArtifact, ResolvedVendorArtifactsManifest, VendorArtifactsManifest, VendorSource,
+    ResolvedVendorArtifact, ResolvedVendorArtifactsManifest, VendorArtifactsManifest,
+    VendorResponseMap, VendorSource,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -80,7 +81,7 @@ fn resolve_vendor_feed(
     url_template: &str,
     manifest_params: &HashMap<String, String>,
     platforms: &HashMap<String, String>,
-    response_map: &HashMap<String, String>,
+    response_map: &VendorResponseMap,
     arch: &str,
 ) -> Result<ResolvedVendorArtifact> {
     // Build parameter map: start with explicit params
@@ -107,16 +108,8 @@ fn resolve_vendor_feed(
     let body: serde_json::Value = http::download_json(&url, &[])
         .with_context(|| format!("failed to fetch vendor feed for '{}'", name))?;
 
-    eprintln!(
-        "  vendor response: {}",
-        serde_json::to_string(&body).unwrap_or_default()
-    );
-
     // Extract fields using response_map
-    let extract = |key: &str| -> Result<String> {
-        let vendor_field = response_map
-            .get(key)
-            .ok_or_else(|| anyhow!("response_map for '{}' missing required key '{}'", name, key))?;
+    let extract = |vendor_field: &str, label: &str| -> Result<String> {
         body[vendor_field]
             .as_str()
             .map(String::from)
@@ -125,23 +118,29 @@ fn resolve_vendor_feed(
                     "vendor response for '{}' missing field '{}' (mapped from '{}')",
                     name,
                     vendor_field,
-                    key
+                    label
                 )
             })
     };
 
-    let artifact_url = extract("url")?;
-    let version = extract("version")?;
-    let sha256 = extract("sha256")?;
+    let artifact_url = extract(&response_map.url, "url")?;
+    let version = extract(&response_map.version, "version")?;
+    let sha256 = extract(&response_map.sha256, "sha256")?;
     let vendor_revision = response_map
-        .get("vendor_revision")
+        .vendor_revision
+        .as_ref()
         .and_then(|field| body[field].as_str().map(String::from));
 
     let kind_str = match kind {
         bkt_common::manifest::ArtifactKind::Rpm => "rpm",
     };
 
-    eprintln!("  → {} {} ({})", name, version, artifact_url);
+    eprintln!("  → {} v{}", name, version);
+    eprintln!("    url: {}", artifact_url);
+    eprintln!("    sha256: {}", sha256);
+    if let Some(rev) = &vendor_revision {
+        eprintln!("    vendor_revision: {}", rev);
+    }
 
     Ok(ResolvedVendorArtifact {
         name: name.to_string(),
@@ -179,7 +178,7 @@ fn expand_template(
             result.replace_range(abs_start..=abs_end, value);
             pos = abs_start + value.len();
         } else {
-            break;
+            bail!("unmatched '{{' in URL template at position {}", abs_start);
         }
     }
 
@@ -226,6 +225,18 @@ fn install_rpm(artifact: &ResolvedVendorArtifact) -> Result<()> {
             artifact.name,
             artifact.sha256,
             actual
+        );
+    }
+
+    // Validate artifact name to prevent path traversal
+    if !artifact
+        .name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        bail!(
+            "invalid artifact name '{}': only [A-Za-z0-9_-] are allowed",
+            artifact.name
         );
     }
 

--- a/bkt-build/src/vendor_artifacts.rs
+++ b/bkt-build/src/vendor_artifacts.rs
@@ -1,0 +1,291 @@
+//! Vendor artifact resolution and installation.
+//!
+//! Resolves vendor feed URLs to concrete artifact metadata, and installs
+//! resolved RPM artifacts during container builds.
+
+use anyhow::{anyhow, bail, Context, Result};
+use bkt_common::checksum::sha256_hex;
+use bkt_common::http;
+use bkt_common::manifest::{
+    ResolvedVendorArtifact, ResolvedVendorArtifactsManifest, VendorArtifactsManifest, VendorSource,
+};
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Resolve all vendor artifacts from a manifest file.
+///
+/// Reads the intent manifest, queries each artifact's vendor feed,
+/// and writes a resolved manifest to the output path.
+pub fn resolve(manifest_path: &Path, output_path: &Path) -> Result<()> {
+    let manifest = VendorArtifactsManifest::load_from(manifest_path)
+        .with_context(|| format!("failed to load manifest from {}", manifest_path.display()))?;
+
+    let arch = std::env::consts::ARCH;
+    let mut resolved = Vec::new();
+
+    for artifact in &manifest.artifacts {
+        let entry = match &artifact.source {
+            VendorSource::VendorFeed {
+                url,
+                params,
+                platforms,
+                response_map,
+            } => resolve_vendor_feed(
+                &artifact.name,
+                &artifact.kind,
+                url,
+                params,
+                platforms,
+                response_map,
+                arch,
+            )?,
+        };
+        resolved.push(entry);
+    }
+
+    let resolved_manifest = ResolvedVendorArtifactsManifest {
+        resolved_at: chrono::Utc::now(),
+        arch: arch.to_string(),
+        artifacts: resolved,
+    };
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(&resolved_manifest)
+        .context("failed to serialize resolved manifest")?;
+    std::fs::write(output_path, &json).with_context(|| {
+        format!(
+            "failed to write resolved manifest to {}",
+            output_path.display()
+        )
+    })?;
+
+    eprintln!(
+        "Resolved {} vendor artifact(s) to {}",
+        resolved_manifest.artifacts.len(),
+        output_path.display()
+    );
+
+    Ok(())
+}
+
+/// Resolve a single vendor-feed artifact using the response_map for field extraction.
+fn resolve_vendor_feed(
+    name: &str,
+    kind: &bkt_common::manifest::ArtifactKind,
+    url_template: &str,
+    manifest_params: &HashMap<String, String>,
+    platforms: &HashMap<String, String>,
+    response_map: &HashMap<String, String>,
+    arch: &str,
+) -> Result<ResolvedVendorArtifact> {
+    // Build parameter map: start with explicit params
+    let mut params = manifest_params.clone();
+
+    // Derive platform from platforms map
+    if let Some(platform) = platforms.get(arch) {
+        params.insert("platform".to_string(), platform.clone());
+    } else if !platforms.is_empty() {
+        bail!(
+            "no platform mapping for architecture '{}' in artifact '{}'",
+            arch,
+            name
+        );
+    }
+
+    // Expand template
+    let url = expand_template(url_template, &params)
+        .with_context(|| format!("failed to expand URL template for artifact '{}'", name))?;
+
+    eprintln!("Resolving {} from {}", name, url);
+
+    // Fetch the vendor feed response
+    let body: serde_json::Value = http::download_json(&url, &[])
+        .with_context(|| format!("failed to fetch vendor feed for '{}'", name))?;
+
+    eprintln!(
+        "  vendor response: {}",
+        serde_json::to_string(&body).unwrap_or_default()
+    );
+
+    // Extract fields using response_map
+    let extract = |key: &str| -> Result<String> {
+        let vendor_field = response_map
+            .get(key)
+            .ok_or_else(|| anyhow!("response_map for '{}' missing required key '{}'", name, key))?;
+        body[vendor_field]
+            .as_str()
+            .map(String::from)
+            .ok_or_else(|| {
+                anyhow!(
+                    "vendor response for '{}' missing field '{}' (mapped from '{}')",
+                    name,
+                    vendor_field,
+                    key
+                )
+            })
+    };
+
+    let artifact_url = extract("url")?;
+    let version = extract("version")?;
+    let sha256 = extract("sha256")?;
+    let vendor_revision = response_map
+        .get("vendor_revision")
+        .and_then(|field| body[field].as_str().map(String::from));
+
+    let kind_str = match kind {
+        bkt_common::manifest::ArtifactKind::Rpm => "rpm",
+    };
+
+    eprintln!("  → {} {} ({})", name, version, artifact_url);
+
+    Ok(ResolvedVendorArtifact {
+        name: name.to_string(),
+        kind: kind_str.to_string(),
+        version,
+        url: artifact_url,
+        sha256,
+        vendor_revision,
+    })
+}
+
+/// Expand `{param}` placeholders in a URL template.
+fn expand_template(
+    template: &str,
+    params: &std::collections::HashMap<String, String>,
+) -> Result<String> {
+    let mut result = template.to_string();
+    let mut pos = 0;
+
+    // Find all {param} placeholders and verify they have values
+    while let Some(start) = result[pos..].find('{') {
+        let abs_start = pos + start;
+        if let Some(end) = result[abs_start..].find('}') {
+            let abs_end = abs_start + end;
+            let param_name = &result[abs_start + 1..abs_end];
+
+            let value = params.get(param_name).ok_or_else(|| {
+                anyhow!(
+                    "missing template parameter '{}' (available: {})",
+                    param_name,
+                    params.keys().cloned().collect::<Vec<_>>().join(", ")
+                )
+            })?;
+
+            result.replace_range(abs_start..=abs_end, value);
+            pos = abs_start + value.len();
+        } else {
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Install a resolved vendor artifact by name.
+///
+/// Reads the resolved manifest, downloads the artifact, verifies its
+/// checksum, and installs it.
+pub fn install(name: &str, resolved_path: &Path) -> Result<()> {
+    let manifest =
+        ResolvedVendorArtifactsManifest::load_from(resolved_path).with_context(|| {
+            format!(
+                "failed to load resolved manifest from {}",
+                resolved_path.display()
+            )
+        })?;
+
+    let artifact = manifest
+        .find(name)
+        .ok_or_else(|| anyhow!("artifact '{}' not found in resolved manifest", name))?;
+
+    match artifact.kind.as_str() {
+        "rpm" => install_rpm(artifact)?,
+        other => bail!("unsupported artifact kind '{}' for '{}'", other, name),
+    }
+
+    Ok(())
+}
+
+/// Download and install an RPM artifact.
+fn install_rpm(artifact: &ResolvedVendorArtifact) -> Result<()> {
+    eprintln!("Downloading {} v{} ...", artifact.name, artifact.version);
+
+    let data = bkt_common::http::download(&artifact.url)
+        .with_context(|| format!("failed to download {}", artifact.name))?;
+
+    eprintln!("Verifying SHA256...");
+    let actual = sha256_hex(&data);
+    if actual != artifact.sha256 {
+        bail!(
+            "SHA256 mismatch for {}: expected {}, got {}",
+            artifact.name,
+            artifact.sha256,
+            actual
+        );
+    }
+
+    // Write RPM to /rpms/ (kept for RPM DB finalization in a later stage)
+    std::fs::create_dir_all("/rpms").context("failed to create /rpms")?;
+    let rpm_path = format!("/rpms/{}.rpm", artifact.name);
+    std::fs::write(&rpm_path, &data)
+        .with_context(|| format!("failed to write RPM to {}", rpm_path))?;
+
+    eprintln!("Installing {} via rpm...", artifact.name);
+    let output = Command::new("rpm")
+        .args(["-i", "--nodb", "--noscripts", "--nodeps", &rpm_path])
+        .output()
+        .with_context(|| format!("failed to execute rpm for {}", artifact.name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("rpm install failed for {}: {}", artifact.name, stderr);
+    }
+
+    eprintln!("Installed {} v{}", artifact.name, artifact.version);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_expand_template_basic() {
+        let mut params = HashMap::new();
+        params.insert("channel".to_string(), "stable".to_string());
+        params.insert("platform".to_string(), "linux-rpm-x64".to_string());
+
+        let result = expand_template(
+            "https://example.com/api/{platform}/{channel}/latest",
+            &params,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            "https://example.com/api/linux-rpm-x64/stable/latest"
+        );
+    }
+
+    #[test]
+    fn test_expand_template_missing_param() {
+        let params = HashMap::new();
+        let result = expand_template("https://example.com/{missing}", &params);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("missing"));
+    }
+
+    #[test]
+    fn test_expand_template_no_placeholders() {
+        let params = HashMap::new();
+        let result = expand_template("https://example.com/plain", &params).unwrap();
+        assert_eq!(result, "https://example.com/plain");
+    }
+}

--- a/bkt-common/src/manifest.rs
+++ b/bkt-common/src/manifest.rs
@@ -309,9 +309,23 @@ pub enum VendorSource {
         platforms: HashMap<String, String>,
 
         /// Maps resolved artifact field names to vendor response JSON field names.
-        /// Required keys: `url`, `version`, `sha256`. Optional: `vendor_revision`.
-        response_map: HashMap<String, String>,
+        response_map: VendorResponseMap,
     },
+}
+
+/// Maps resolved artifact field names to vendor response JSON field names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct VendorResponseMap {
+    /// Vendor response field containing the download URL
+    pub url: String,
+    /// Vendor response field containing the version string
+    pub version: String,
+    /// Vendor response field containing the SHA256 checksum
+    pub sha256: String,
+    /// Vendor response field containing a revision identifier (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor_revision: Option<String>,
 }
 
 impl VendorArtifactsManifest {

--- a/bkt-common/src/manifest.rs
+++ b/bkt-common/src/manifest.rs
@@ -1,6 +1,7 @@
 use crate::error::CommonError;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -225,5 +226,151 @@ impl ExternalReposManifest {
     /// Find an external repository by name.
     pub fn find(&self, name: &str) -> Option<&ExternalRepo> {
         self.repos.iter().find(|repo| repo.name == name)
+    }
+}
+
+// ── Vendor artifacts (intent manifest types) ────────────────────────────────
+
+/// Controls how a package is grouped for deployment layers.
+///
+/// Build stages are always per-package (for cache efficiency).
+/// This field controls deployment layer consolidation to avoid
+/// btrfs hardlink limits in ostree.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum LayerGroup {
+    /// Package gets its own deployment layer.
+    /// Use for high-churn, large packages (e.g., vscode, edge).
+    Independent,
+    /// Package is grouped with other bundled packages.
+    /// Use for low-churn, smaller packages.
+    #[default]
+    Bundled,
+}
+
+/// The vendor-artifacts.json manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct VendorArtifactsManifest {
+    #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+
+    pub artifacts: Vec<VendorArtifact>,
+}
+
+/// A single vendor artifact entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct VendorArtifact {
+    /// Unique identifier (e.g., "code")
+    pub name: String,
+
+    /// Human-readable name (e.g., "Visual Studio Code")
+    pub display_name: String,
+
+    /// Artifact type
+    pub kind: ArtifactKind,
+
+    /// How to discover the latest artifact
+    pub source: VendorSource,
+
+    /// Controls deployment layer grouping. Defaults to bundled.
+    #[serde(default)]
+    pub layer_group: LayerGroup,
+}
+
+/// The type of artifact being installed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactKind {
+    /// RPM package
+    Rpm,
+}
+
+/// Discovery specification for a vendor artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum VendorSource {
+    /// Vendor release feed with templated URL
+    VendorFeed {
+        /// URL template with `{param}` placeholders
+        url: String,
+
+        /// Key-value parameters for template substitution
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        params: HashMap<String, String>,
+
+        /// Architecture → platform identifier mapping.
+        /// The resolved platform value is available as `{platform}` in the URL template.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        platforms: HashMap<String, String>,
+
+        /// Maps resolved artifact field names to vendor response JSON field names.
+        /// Required keys: `url`, `version`, `sha256`. Optional: `vendor_revision`.
+        response_map: HashMap<String, String>,
+    },
+}
+
+impl VendorArtifactsManifest {
+    pub const PROJECT_PATH: &'static str = "manifests/vendor-artifacts.json";
+
+    /// Load from a specific path.
+    pub fn load_from(path: &Path) -> Result<Self, CommonError> {
+        let content = fs::read_to_string(path)?;
+        let manifest: Self = serde_json::from_str(&content)?;
+        Ok(manifest)
+    }
+
+    /// Find an artifact by name.
+    pub fn find(&self, name: &str) -> Option<&VendorArtifact> {
+        self.artifacts.iter().find(|a| a.name == name)
+    }
+}
+
+// ── Resolved vendor artifacts (build-time resolution output) ────────────────
+
+/// A resolved vendor artifact, produced by the resolver and consumed by the build.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedVendorArtifact {
+    /// Artifact name (matches manifest entry)
+    pub name: String,
+    /// Artifact type
+    pub kind: String,
+    /// Resolved version string
+    pub version: String,
+    /// Direct download URL for the artifact
+    pub url: String,
+    /// SHA256 checksum of the artifact
+    pub sha256: String,
+    /// Vendor-specific revision identifier (e.g., commit hash)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor_revision: Option<String>,
+}
+
+/// The resolved vendor artifacts file (`.cache/bkt/vendor-artifacts.resolved.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedVendorArtifactsManifest {
+    /// When resolution was performed
+    pub resolved_at: DateTime<Utc>,
+    /// Build architecture
+    pub arch: String,
+    /// Resolved artifacts
+    pub artifacts: Vec<ResolvedVendorArtifact>,
+}
+
+impl ResolvedVendorArtifactsManifest {
+    /// Load from a specific path.
+    pub fn load_from(path: &Path) -> Result<Self, CommonError> {
+        let content = fs::read_to_string(path)?;
+        let manifest: Self = serde_json::from_str(&content)?;
+        Ok(manifest)
+    }
+
+    /// Find a resolved artifact by name.
+    pub fn find(&self, name: &str) -> Option<&ResolvedVendorArtifact> {
+        self.artifacts.iter().find(|a| a.name == name)
     }
 }

--- a/bkt/src/commands/containerfile.rs
+++ b/bkt/src/commands/containerfile.rs
@@ -18,6 +18,7 @@ use crate::manifest::system_config::SystemConfigManifest;
 use crate::manifest::upstream::ManifestRepo as UpstreamManifestRepo;
 use crate::manifest::{
     ExternalReposManifest, ShimsManifest, SystemPackagesManifest, UpstreamManifest,
+    VendorArtifactsManifest,
 };
 use crate::output::Output;
 use crate::pipeline::ExecutionPlan;
@@ -446,6 +447,24 @@ fn load_generator_input() -> Result<ContainerfileGeneratorInput> {
 
     let has_external_rpms = !external_repos.repos.is_empty();
 
+    let vendor_artifacts_path = repo_path.join("manifests").join("vendor-artifacts.json");
+    let vendor_artifacts = if vendor_artifacts_path.exists() {
+        let content = std::fs::read_to_string(&vendor_artifacts_path).with_context(|| {
+            format!(
+                "Failed to read vendor artifacts manifest from {}",
+                vendor_artifacts_path.display()
+            )
+        })?;
+        serde_json::from_str(&content).with_context(|| {
+            format!(
+                "Failed to parse vendor artifacts manifest from {}",
+                vendor_artifacts_path.display()
+            )
+        })?
+    } else {
+        VendorArtifactsManifest::default()
+    };
+
     Ok(ContainerfileGeneratorInput {
         external_repos,
         upstreams,
@@ -455,5 +474,6 @@ fn load_generator_input() -> Result<ContainerfileGeneratorInput> {
         image_config,
         shims: shims_manifest.shims,
         has_external_rpms,
+        vendor_artifacts,
     })
 }

--- a/bkt/src/commands/schema.rs
+++ b/bkt/src/commands/schema.rs
@@ -4,7 +4,7 @@ use crate::manifest::{
     BaseImageAssumptions, ChangelogEntry, DistroboxManifest, ExternalReposManifest, FlatpakApp,
     FlatpakAppsManifest, FlatpakRemote, FlatpakRemotesManifest, GSetting, GSettingsManifest,
     GnomeExtensionsManifest, HomebrewManifest, HostBinariesManifest, Shim, ShimsManifest,
-    UpstreamManifest, VersionMetadata,
+    UpstreamManifest, VendorArtifactsManifest, VersionMetadata,
 };
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
@@ -123,6 +123,11 @@ const SCHEMAS: &[SchemaInfo] = &[
         filename: "host-binaries.schema.json",
         description: "The host-binaries.json manifest (binaries installed via fetchbin)",
     },
+    SchemaInfo {
+        name: "VendorArtifactsManifest",
+        filename: "vendor-artifacts.schema.json",
+        description: "The vendor-artifacts.json manifest (vendor-sourced packages like VS Code)",
+    },
 ];
 
 /// Generate all schemas and return them as (filename, json) pairs.
@@ -195,6 +200,10 @@ fn generate_all_schemas() -> Vec<(&'static str, String)> {
         (
             "host-binaries.schema.json",
             serde_json::to_string_pretty(&schema_for!(HostBinariesManifest)).unwrap(),
+        ),
+        (
+            "vendor-artifacts.schema.json",
+            serde_json::to_string_pretty(&schema_for!(VendorArtifactsManifest)).unwrap(),
         ),
     ]
 }

--- a/bkt/src/containerfile.rs
+++ b/bkt/src/containerfile.rs
@@ -303,6 +303,7 @@ pub fn generate_full_containerfile(input: &ContainerfileGeneratorInput) -> Strin
     emit_install_stages(&mut lines, &input.external_repos);
     emit_bundled_stage(&mut lines, &input.external_repos);
     emit_vendor_artifact_stages(&mut lines, &input.vendor_artifacts);
+    emit_vendor_bundled_stage(&mut lines, &input.vendor_artifacts);
     emit_fetch_stages(&mut lines, &input.upstreams);
     emit_script_stages(&mut lines, &input.upstreams);
     emit_wrapper_build_stage(&mut lines, &input.image_config);
@@ -486,10 +487,50 @@ fn emit_vendor_artifact_stages(lines: &mut Vec<String>, manifest: &VendorArtifac
     }
 }
 
+/// Emit a merged stage for bundled vendor artifacts (if any exist).
+fn emit_vendor_bundled_stage(lines: &mut Vec<String>, manifest: &VendorArtifactsManifest) {
+    let bundled: Vec<_> = manifest
+        .artifacts
+        .iter()
+        .filter(|a| a.layer_group == LayerGroup::Bundled)
+        .collect();
+
+    if bundled.is_empty() {
+        return;
+    }
+
+    lines.push("".to_string());
+    lines.push(section_header(
+        "Bundled vendor artifacts merged stage (reduces deployment layer count)",
+    ));
+    lines.push("".to_string());
+    lines.push("FROM scratch AS vendor-bundled".to_string());
+    for artifact in &bundled {
+        lines.push(format!("COPY --from=vendor-{} /usr/ /usr/", artifact.name));
+    }
+}
+
 /// Emit COPY instructions from vendor-* stages into final image.
+/// Only copies installed package files, excluding build-time artifacts
+/// (/rpms/ and /tmp/) that should not ship in the final image.
+/// Independent artifacts get their own COPY; bundled artifacts share one layer.
 fn emit_vendor_artifact_copies(lines: &mut Vec<String>, manifest: &VendorArtifactsManifest) {
-    for artifact in &manifest.artifacts {
-        lines.push(format!("COPY --from=vendor-{} / /", artifact.name));
+    let independent: Vec<_> = manifest
+        .artifacts
+        .iter()
+        .filter(|a| a.layer_group == LayerGroup::Independent)
+        .collect();
+    let has_bundled = manifest
+        .artifacts
+        .iter()
+        .any(|a| a.layer_group == LayerGroup::Bundled);
+
+    for artifact in &independent {
+        lines.push(format!("COPY --from=vendor-{} /usr/ /usr/", artifact.name));
+    }
+
+    if has_bundled {
+        lines.push("COPY --from=vendor-bundled / /".to_string());
     }
 }
 

--- a/bkt/src/containerfile.rs
+++ b/bkt/src/containerfile.rs
@@ -477,7 +477,7 @@ fn emit_vendor_artifact_stages(lines: &mut Vec<String>, manifest: &VendorArtifac
         }
         lines.push(format!("FROM base AS vendor-{}", artifact.name));
         lines.push(
-            "COPY .cache/bkt/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json"
+            "COPY build/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json"
                 .to_string(),
         );
         lines.push(format!(

--- a/bkt/src/containerfile.rs
+++ b/bkt/src/containerfile.rs
@@ -21,6 +21,7 @@
 
 use crate::manifest::ExternalReposManifest;
 use crate::manifest::Shim;
+use crate::manifest::VendorArtifactsManifest;
 use crate::manifest::external_repos::LayerGroup;
 use crate::manifest::image_config::{FileCopy, ImageConfigManifest, ImageModule};
 use crate::manifest::system_config::SystemConfigManifest;
@@ -289,6 +290,7 @@ pub struct ContainerfileGeneratorInput {
     pub image_config: ImageConfigManifest,
     pub shims: Vec<Shim>,
     pub has_external_rpms: bool,
+    pub vendor_artifacts: VendorArtifactsManifest,
 }
 
 /// Generate the full Containerfile from manifests.
@@ -300,6 +302,7 @@ pub fn generate_full_containerfile(input: &ContainerfileGeneratorInput) -> Strin
     emit_dl_stages(&mut lines, &input.external_repos);
     emit_install_stages(&mut lines, &input.external_repos);
     emit_bundled_stage(&mut lines, &input.external_repos);
+    emit_vendor_artifact_stages(&mut lines, &input.vendor_artifacts);
     emit_fetch_stages(&mut lines, &input.upstreams);
     emit_script_stages(&mut lines, &input.upstreams);
     emit_wrapper_build_stage(&mut lines, &input.image_config);
@@ -455,6 +458,41 @@ fn emit_bundled_stage(lines: &mut Vec<String>, repos: &ExternalReposManifest) {
     }
 }
 
+/// Emit vendor artifact build stages (parallel, each fetches and installs one resolved artifact).
+fn emit_vendor_artifact_stages(lines: &mut Vec<String>, manifest: &VendorArtifactsManifest) {
+    if manifest.artifacts.is_empty() {
+        return;
+    }
+
+    lines.push("".to_string());
+    lines.push(section_header(
+        "Vendor artifact stages (parallel, each fetches one resolved artifact)",
+    ));
+    lines.push("".to_string());
+
+    for (idx, artifact) in manifest.artifacts.iter().enumerate() {
+        if idx > 0 {
+            lines.push("".to_string());
+        }
+        lines.push(format!("FROM base AS vendor-{}", artifact.name));
+        lines.push(
+            "COPY .cache/bkt/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json"
+                .to_string(),
+        );
+        lines.push(format!(
+            "RUN bkt-build install-vendor-artifact {}",
+            artifact.name
+        ));
+    }
+}
+
+/// Emit COPY instructions from vendor-* stages into final image.
+fn emit_vendor_artifact_copies(lines: &mut Vec<String>, manifest: &VendorArtifactsManifest) {
+    for artifact in &manifest.artifacts {
+        lines.push(format!("COPY --from=vendor-{} / /", artifact.name));
+    }
+}
+
 /// Emit COPY --link instructions from install-* stages into final image.
 /// Independent packages get their own layer; bundled packages share one layer.
 fn emit_install_copies(lines: &mut Vec<String>, repos: &ExternalReposManifest) {
@@ -486,17 +524,33 @@ fn emit_install_copies(lines: &mut Vec<String>, repos: &ExternalReposManifest) {
 }
 
 /// Emit RPM database finalization after all file payloads are in place.
-fn emit_rpm_db_finalization(lines: &mut Vec<String>, repos: &ExternalReposManifest) {
-    if repos.repos.is_empty() {
+fn emit_rpm_db_finalization(
+    lines: &mut Vec<String>,
+    repos: &ExternalReposManifest,
+    vendor_artifacts: &VendorArtifactsManifest,
+) {
+    let has_repos = !repos.repos.is_empty();
+    let has_vendor = !vendor_artifacts.artifacts.is_empty();
+
+    if !has_repos && !has_vendor {
         return;
     }
 
     lines.push("# Finalize RPM database for external packages".to_string());
-    // Copy RPMs to separate dirs to avoid filename collisions
+
+    // Copy RPMs from external repo dl-* stages
     for repo in &repos.repos {
         lines.push(format!(
             "COPY --from=dl-{} /rpms/ /tmp/rpms-{}/",
             repo.name, repo.name
+        ));
+    }
+
+    // Copy RPMs from vendor-* stages
+    for artifact in &vendor_artifacts.artifacts {
+        lines.push(format!(
+            "COPY --from=vendor-{} /rpms/ /tmp/rpms-vendor-{}/",
+            artifact.name, artifact.name
         ));
     }
 
@@ -507,14 +561,23 @@ fn emit_rpm_db_finalization(lines: &mut Vec<String>, repos: &ExternalReposManife
             repo.name, LINE_CONT
         ));
     }
+    for artifact in &vendor_artifacts.artifacts {
+        lines.push(format!(
+            "    rpm -i --justdb --nodeps /tmp/rpms-vendor-{}/*.rpm; {}",
+            artifact.name, LINE_CONT
+        ));
+    }
     lines.push(format!("    ldconfig; {}", LINE_CONT));
 
     // Cleanup
-    let cleanup_parts: Vec<String> = repos
+    let mut cleanup_parts: Vec<String> = repos
         .repos
         .iter()
         .map(|r| format!("/tmp/rpms-{}", r.name))
         .collect();
+    for artifact in &vendor_artifacts.artifacts {
+        cleanup_parts.push(format!("/tmp/rpms-vendor-{}", artifact.name));
+    }
     lines.push(format!("    rm -rf {}", cleanup_parts.join(" ")));
 }
 
@@ -818,6 +881,8 @@ fn emit_image_assembly(lines: &mut Vec<String>, input: &ContainerfileGeneratorIn
 
     // Per-package RPM file payloads (COPY --link for layer independence)
     emit_install_copies(lines, &input.external_repos);
+    // Vendor artifact file payloads
+    emit_vendor_artifact_copies(lines, &input.vendor_artifacts);
     lines.push("".to_string());
 
     // System packages only (external RPMs handled via install stages)
@@ -834,7 +899,7 @@ fn emit_image_assembly(lines: &mut Vec<String>, input: &ContainerfileGeneratorIn
     lines.push("".to_string());
 
     // RPM database finalization (--justdb + ldconfig)
-    emit_rpm_db_finalization(lines, &input.external_repos);
+    emit_rpm_db_finalization(lines, &input.external_repos, &input.vendor_artifacts);
     lines.push("".to_string());
 
     emit_cleanup(lines);
@@ -1469,6 +1534,7 @@ COPY . /app
             },
             shims: Vec::new(),
             has_external_rpms: false,
+            vendor_artifacts: VendorArtifactsManifest::default(),
         };
 
         let output = generate_full_containerfile(&input);

--- a/bkt/src/manifest/external_repos.rs
+++ b/bkt/src/manifest/external_repos.rs
@@ -1,23 +1,7 @@
 //! External RPM repositories manifest types.
+pub use bkt_common::manifest::LayerGroup;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-/// Controls how a package is grouped for deployment layers.
-///
-/// Build stages are always per-package (for cache efficiency).
-/// This field controls deployment layer consolidation to avoid
-/// btrfs hardlink limits in ostree.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum LayerGroup {
-    /// Package gets its own deployment layer.
-    /// Use for high-churn, large packages (e.g., vscode, edge).
-    Independent,
-    /// Package is grouped with other bundled packages.
-    /// Use for low-churn, smaller packages.
-    #[default]
-    Bundled,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct ExternalReposManifest {

--- a/bkt/src/manifest/mod.rs
+++ b/bkt/src/manifest/mod.rs
@@ -24,6 +24,7 @@ pub mod systemd_services;
 pub mod toolbox;
 pub mod try_pending;
 pub mod upstream;
+pub mod vendor_artifacts;
 
 pub use appimage::*;
 pub use base::*;
@@ -41,3 +42,4 @@ pub use systemd_services::*;
 pub use toolbox::*;
 pub use try_pending::*;
 pub use upstream::*;
+pub use vendor_artifacts::*;

--- a/bkt/src/manifest/vendor_artifacts.rs
+++ b/bkt/src/manifest/vendor_artifacts.rs
@@ -1,0 +1,9 @@
+//! Vendor artifacts manifest types.
+//!
+//! Re-exports from `bkt-common` so the types are shared between `bkt` and `bkt-build`.
+//! The manifest captures intent ("follow latest stable VS Code"); resolved
+//! versions are a build artifact, not tracked in git.
+
+pub use bkt_common::manifest::{
+    ArtifactKind, VendorArtifact, VendorArtifactsManifest, VendorSource,
+};

--- a/docs/rfcs/0056-vendor-artifacts.md
+++ b/docs/rfcs/0056-vendor-artifacts.md
@@ -45,6 +45,12 @@ Git-tracked intent manifest. Declares what to follow, not what version to use.
         "platforms": {
           "x86_64": "linux-rpm-x64",
           "aarch64": "linux-rpm-arm64"
+        },
+        "response_map": {
+          "url": "url",
+          "version": "productVersion",
+          "sha256": "sha256hash",
+          "vendor_revision": "version"
         }
       },
       "layer_group": "independent"
@@ -67,10 +73,11 @@ Git-tracked intent manifest. Declares what to follow, not what version to use.
 
 | Field       | Required | Description                                    |
 | ----------- | -------- | ---------------------------------------------- |
-| `type`      | yes      | Source type (`vendor-feed`)                    |
-| `url`       | yes      | URL template with `{param}` placeholders       |
-| `params`    | no       | Key-value parameters for template substitution |
-| `platforms` | no       | Architecture → platform identifier mapping     |
+| `type`         | yes      | Source type (`vendor-feed`)                                              |
+| `url`          | yes      | URL template with `{param}` placeholders                                 |
+| `params`       | no       | Key-value parameters for template substitution                           |
+| `platforms`    | no       | Architecture → platform identifier mapping                               |
+| `response_map` | yes      | Maps resolved field names (`url`, `version`, `sha256`) to vendor JSON fields |
 
 ### Template Substitution
 
@@ -100,11 +107,7 @@ Generated file, not checked into git. Produced by the resolver, consumed by the 
       "version": "1.111.0",
       "url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/ce099c1ed25d9eb3076c11e4a280f3eb52b4fbeb/code-1.111.0-1772846667.el8.x86_64.rpm",
       "sha256": "c64f744ce4091b940c800dda8ba19d3c56c495bde6a100b2d19ae564d0c81bf2",
-      "vendor_revision": "ce099c1ed25d9eb3076c11e4a280f3eb52b4fbeb",
-      "metadata": {
-        "productVersion": "1.111.0",
-        "timestamp": 1772846448148
-      }
+      "vendor_revision": "ce099c1ed25d9eb3076c11e4a280f3eb52b4fbeb"
     }
   ]
 }
@@ -121,7 +124,7 @@ The resolver reads `manifests/vendor-artifacts.json`, queries each artifact's so
 3. Combine with `source.params`
 4. Expand URL template
 5. HTTP GET the expanded URL
-6. Parse JSON response (expects `url`, `productVersion`/`name`, `sha256hash`, `version`)
+6. Parse JSON response, extracting fields via `response_map`
 7. Write resolved entry
 
 **Command:** `bkt-build resolve-vendor-artifacts`

--- a/docs/rfcs/0056-vendor-artifacts.md
+++ b/docs/rfcs/0056-vendor-artifacts.md
@@ -1,0 +1,244 @@
+# RFC 0056: Vendor Artifacts
+
+| Status     | Draft                                                    |
+| ---------- | -------------------------------------------------------- |
+| Created    | 2026-03-12                                               |
+| Depends on | RFC-0045 (Layer Minimization), RFC-0050 (Layer Grouping) |
+
+## Problem Statement
+
+External RPM packages like VS Code are currently sourced from vendor YUM repositories via `external-repos.json`. The build downloads packages using `dnf download --enablerepo=<name>`, which depends on the vendor keeping their YUM repo metadata up to date.
+
+In practice, vendors like Microsoft publish new RPM artifacts to their direct download CDN **before** updating their YUM repository metadata. VS Code 1.111.0 was available via the direct download API for days while the YUM repo still only advertised 1.110.1.
+
+This means the current pipeline silently delivers stale packages even when the vendor has already released updates.
+
+## Solution
+
+Introduce a **vendor artifacts** manifest that describes how to discover and install packages directly from vendor release feeds, bypassing stale YUM repository metadata.
+
+### Design Principles
+
+1. **Git tracks intent, not resolved state.** The manifest declares "follow latest stable VS Code." It does not pin a specific version.
+2. **Resolution is a build artifact.** A resolver step queries vendor APIs and produces a generated resolution file consumed by the build. This file is not checked into git.
+3. **Generic template substitution.** Discovery URLs use `{param}` placeholders filled from manifest-supplied parameters. No vendor-specific logic in the template engine.
+4. **Builds are internally consistent.** Resolution happens once per build cycle. The build consumes the resolved artifact, never the live vendor API.
+
+### Manifest: `manifests/vendor-artifacts.json`
+
+Git-tracked intent manifest. Declares what to follow, not what version to use.
+
+```json
+{
+  "$schema": "../schemas/vendor-artifacts.schema.json",
+  "artifacts": [
+    {
+      "name": "code",
+      "display_name": "Visual Studio Code",
+      "kind": "rpm",
+      "source": {
+        "type": "vendor-feed",
+        "url": "https://update.code.visualstudio.com/api/update/{platform}/{channel}/latest",
+        "params": {
+          "channel": "stable"
+        },
+        "platforms": {
+          "x86_64": "linux-rpm-x64",
+          "aarch64": "linux-rpm-arm64"
+        }
+      },
+      "layer_group": "independent"
+    }
+  ]
+}
+```
+
+**Fields:**
+
+| Field          | Required | Description                                                               |
+| -------------- | -------- | ------------------------------------------------------------------------- |
+| `name`         | yes      | Unique identifier                                                         |
+| `display_name` | yes      | Human-readable name                                                       |
+| `kind`         | yes      | Artifact type (`rpm` for now)                                             |
+| `source`       | yes      | Discovery specification                                                   |
+| `layer_group`  | no       | Deployment layer grouping (`independent` or `bundled`, default `bundled`) |
+
+**Source fields:**
+
+| Field       | Required | Description                                    |
+| ----------- | -------- | ---------------------------------------------- |
+| `type`      | yes      | Source type (`vendor-feed`)                    |
+| `url`       | yes      | URL template with `{param}` placeholders       |
+| `params`    | no       | Key-value parameters for template substitution |
+| `platforms` | no       | Architecture → platform identifier mapping     |
+
+### Template Substitution
+
+All `{param}` placeholders in `source.url` are expanded from:
+
+1. `source.params` — explicit key-value pairs
+2. `platform` — derived from `source.platforms[current_arch]`
+
+**Rules:**
+
+- Missing placeholder parameter → hard error
+- Template parameters are simple string substitution
+- No vendor-specific logic in the template engine
+
+### Resolution Artifact: `.cache/bkt/vendor-artifacts.resolved.json`
+
+Generated file, not checked into git. Produced by the resolver, consumed by the build.
+
+```json
+{
+  "resolved_at": "2026-03-12T00:00:00Z",
+  "arch": "x86_64",
+  "artifacts": [
+    {
+      "name": "code",
+      "kind": "rpm",
+      "version": "1.111.0",
+      "url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/ce099c1ed25d9eb3076c11e4a280f3eb52b4fbeb/code-1.111.0-1772846667.el8.x86_64.rpm",
+      "sha256": "c64f744ce4091b940c800dda8ba19d3c56c495bde6a100b2d19ae564d0c81bf2",
+      "vendor_revision": "ce099c1ed25d9eb3076c11e4a280f3eb52b4fbeb",
+      "metadata": {
+        "productVersion": "1.111.0",
+        "timestamp": 1772846448148
+      }
+    }
+  ]
+}
+```
+
+### Resolver
+
+The resolver reads `manifests/vendor-artifacts.json`, queries each artifact's source URL, and writes the resolution artifact.
+
+**For `vendor-feed` sources:**
+
+1. Determine current architecture
+2. Look up `platform` from `source.platforms[arch]`
+3. Combine with `source.params`
+4. Expand URL template
+5. HTTP GET the expanded URL
+6. Parse JSON response (expects `url`, `productVersion`/`name`, `sha256hash`, `version`)
+7. Write resolved entry
+
+**Command:** `bkt-build resolve-vendor-artifacts`
+
+Runs inside CI before the Docker build. Writes `.cache/bkt/vendor-artifacts.resolved.json`.
+
+### Build Integration
+
+The Containerfile generator emits stages for vendor artifacts:
+
+```dockerfile
+# ── Vendor artifact stages (parallel, each fetches one resolved artifact) ────
+
+FROM base AS vendor-code
+COPY .cache/bkt/vendor-artifacts.resolved.json /tmp/vendor-artifacts.resolved.json
+RUN bkt-build install-vendor-artifact code
+
+# In final image assembly:
+COPY --from=vendor-code / /
+```
+
+`bkt-build install-vendor-artifact` reads the resolved manifest, finds the named artifact, downloads the exact URL, verifies SHA256, and installs via `rpm -i --nodb --noscripts --nodeps`.
+
+### CI Workflow
+
+New step in `.github/workflows/build.yml`, after `validate-manifests` and before `build`:
+
+```yaml
+- name: Resolve vendor artifacts
+  run: |
+    ./scripts/bkt-build resolve-vendor-artifacts \
+      --manifest manifests/vendor-artifacts.json \
+      --output .cache/bkt/vendor-artifacts.resolved.json
+```
+
+The resolved file is then available in the Docker build context.
+
+### Migration from `external-repos.json`
+
+When a package moves from `external-repos.json` to `vendor-artifacts.json`:
+
+1. Remove the repo entry from `external-repos.json`
+2. Add the artifact entry to `vendor-artifacts.json`
+3. Regenerate Containerfile: `bkt containerfile generate`
+4. The build now sources the package from the vendor feed instead of the YUM repo
+
+For VS Code specifically:
+
+- Remove the `code` repo from `external-repos.json`
+- Keep `code-insiders` in `external-repos.json` (or move it too with `channel: "insider"`)
+- Add `code` to `vendor-artifacts.json`
+
+### Image Labels
+
+Resolved vendor artifact metadata is baked into OCI image labels:
+
+```
+org.wycats.bootc.vendor-artifact.code.version=1.111.0
+org.wycats.bootc.vendor-artifact.code.sha256=c64f...
+```
+
+## Implementation Plan
+
+### Phase 1: Manifest and Types
+
+1. Add `VendorArtifactsManifest` types to `bkt/src/manifest/vendor_artifacts.rs`
+2. Add shared types to `bkt-common/src/manifest.rs`
+3. Register schema in `bkt/src/commands/schema.rs`
+4. Create `manifests/vendor-artifacts.json` with VS Code entry
+
+### Phase 2: Resolver
+
+1. Add `resolve-vendor-artifacts` command to `bkt-build`
+2. Implement template substitution
+3. Implement vendor-feed HTTP resolution
+4. Write `.cache/bkt/vendor-artifacts.resolved.json`
+
+### Phase 3: Build Integration
+
+1. Add `install-vendor-artifact` command to `bkt-build`
+2. Integrate into Containerfile generator (new emit functions)
+3. Update `load_generator_input()` to load vendor artifacts manifest
+4. Update CI workflow
+
+### Phase 4: Migration
+
+1. Move VS Code from `external-repos.json` to `vendor-artifacts.json`
+2. Regenerate Containerfile
+3. Verify build produces correct image
+
+## Alternatives Considered
+
+### Extend `external-repos.json` with direct URL support
+
+- **Con:** Mixes repo-based and direct-download semantics
+- **Con:** `baseurl` and `gpg_key` become awkward nullable fields
+- **Con:** `bkt-build download-rpms` would need major refactor
+- **Verdict:** Wrong abstraction level
+
+### Extend `upstream/manifest.json` with RPM install type
+
+- **Pro:** Reuses existing pinning infrastructure
+- **Con:** Upstream model assumes git-tracked pinned versions
+- **Con:** RPM install has different semantics than archive/binary
+- **Verdict:** Close but pinning model conflicts with "follow latest" goal
+
+### Pin versions in git manifest
+
+- **Pro:** Fully deterministic builds from git alone
+- **Con:** Requires git commit for every upstream release
+- **Con:** Fundamentally conflicts with project philosophy (git = intent, not upstream freshness)
+- **Verdict:** Wrong tradeoff for this project
+
+## Success Criteria
+
+1. VS Code updates appear in builds within hours of vendor release
+2. No git commit required for upstream version bumps
+3. Builds remain internally consistent (one resolution per build)
+4. `bkt containerfile check` passes
+5. Migration from `external-repos.json` is clean and reversible

--- a/manifests/external-repos.json
+++ b/manifests/external-repos.json
@@ -2,14 +2,6 @@
   "$schema": "../schemas/external-repos.schema.json",
   "repos": [
     {
-      "name": "code",
-      "display_name": "Visual Studio Code",
-      "baseurl": "https://packages.microsoft.com/yumrepos/vscode",
-      "gpg_key": "https://packages.microsoft.com/keys/microsoft.asc",
-      "packages": ["code", "code-insiders"],
-      "layer_group": "independent"
-    },
-    {
       "name": "microsoft-edge",
       "display_name": "microsoft-edge",
       "baseurl": "https://packages.microsoft.com/yumrepos/edge",

--- a/manifests/vendor-artifacts.json
+++ b/manifests/vendor-artifacts.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../schemas/vendor-artifacts.schema.json",
+  "artifacts": [
+    {
+      "name": "code",
+      "display_name": "Visual Studio Code",
+      "kind": "rpm",
+      "source": {
+        "type": "vendor-feed",
+        "url": "https://update.code.visualstudio.com/api/update/{platform}/{channel}/latest",
+        "params": {
+          "channel": "stable"
+        },
+        "platforms": {
+          "x86_64": "linux-rpm-x64",
+          "aarch64": "linux-rpm-arm64"
+        },
+        "response_map": {
+          "url": "url",
+          "version": "productVersion",
+          "sha256": "sha256hash",
+          "vendor_revision": "version"
+        }
+      },
+      "layer_group": "independent"
+    }
+  ]
+}

--- a/schemas/vendor-artifacts.schema.json
+++ b/schemas/vendor-artifacts.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VendorArtifactsManifest",
+  "description": "The vendor-artifacts.json manifest.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/VendorArtifact"
+      }
+    }
+  },
+  "required": [
+    "artifacts"
+  ],
+  "$defs": {
+    "ArtifactKind": {
+      "description": "The type of artifact being installed.",
+      "oneOf": [
+        {
+          "description": "RPM package",
+          "type": "string",
+          "const": "rpm"
+        }
+      ]
+    },
+    "LayerGroup": {
+      "description": "Controls how a package is grouped for deployment layers.\n\nBuild stages are always per-package (for cache efficiency).\nThis field controls deployment layer consolidation to avoid\nbtrfs hardlink limits in ostree.",
+      "oneOf": [
+        {
+          "description": "Package gets its own deployment layer.\nUse for high-churn, large packages (e.g., vscode, edge).",
+          "type": "string",
+          "const": "independent"
+        },
+        {
+          "description": "Package is grouped with other bundled packages.\nUse for low-churn, smaller packages.",
+          "type": "string",
+          "const": "bundled"
+        }
+      ]
+    },
+    "VendorArtifact": {
+      "description": "A single vendor artifact entry.",
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "description": "Human-readable name (e.g., \"Visual Studio Code\")",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Artifact type",
+          "$ref": "#/$defs/ArtifactKind"
+        },
+        "layer_group": {
+          "description": "Controls deployment layer grouping. Defaults to bundled.",
+          "$ref": "#/$defs/LayerGroup",
+          "default": "bundled"
+        },
+        "name": {
+          "description": "Unique identifier (e.g., \"code\")",
+          "type": "string"
+        },
+        "source": {
+          "description": "How to discover the latest artifact",
+          "$ref": "#/$defs/VendorSource"
+        }
+      },
+      "required": [
+        "name",
+        "display_name",
+        "kind",
+        "source"
+      ]
+    },
+    "VendorSource": {
+      "description": "Discovery specification for a vendor artifact.",
+      "oneOf": [
+        {
+          "description": "Vendor release feed with templated URL",
+          "type": "object",
+          "properties": {
+            "params": {
+              "description": "Key-value parameters for template substitution",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "platforms": {
+              "description": "Architecture → platform identifier mapping.\nThe resolved platform value is available as `{platform}` in the URL template.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "response_map": {
+              "description": "Maps resolved artifact field names to vendor response JSON field names.\nRequired keys: `url`, `version`, `sha256`. Optional: `vendor_revision`.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "vendor-feed"
+            },
+            "url": {
+              "description": "URL template with `{param}` placeholders",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "url",
+            "response_map"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/schemas/vendor-artifacts.schema.json
+++ b/schemas/vendor-artifacts.schema.json
@@ -79,6 +79,36 @@
         "source"
       ]
     },
+    "VendorResponseMap": {
+      "description": "Maps resolved artifact field names to vendor response JSON field names.",
+      "type": "object",
+      "properties": {
+        "sha256": {
+          "description": "Vendor response field containing the SHA256 checksum",
+          "type": "string"
+        },
+        "url": {
+          "description": "Vendor response field containing the download URL",
+          "type": "string"
+        },
+        "vendor_revision": {
+          "description": "Vendor response field containing a revision identifier (optional)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "description": "Vendor response field containing the version string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "version",
+        "sha256"
+      ]
+    },
     "VendorSource": {
       "description": "Discovery specification for a vendor artifact.",
       "oneOf": [
@@ -101,11 +131,8 @@
               }
             },
             "response_map": {
-              "description": "Maps resolved artifact field names to vendor response JSON field names.\nRequired keys: `url`, `version`, `sha256`. Optional: `vendor_revision`.",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "description": "Maps resolved artifact field names to vendor response JSON field names.",
+              "$ref": "#/$defs/VendorResponseMap"
             },
             "type": {
               "type": "string",


### PR DESCRIPTION
## Problem

External RPM packages like VS Code are sourced from vendor YUM repositories via `external-repos.json`. The build downloads packages using `dnf download`, which depends on the vendor keeping their YUM repo metadata up to date.

In practice, Microsoft publishes new RPM artifacts to their direct download CDN **before** updating their YUM repository metadata. VS Code 1.111.0 was available via the direct download API for days while the YUM repo still only advertised 1.110.1.

## Solution

New **vendor artifacts** subsystem that sources packages directly from vendor release feeds, bypassing stale YUM repository metadata.

### Design Principles

- **Git tracks intent, not resolved state.** The manifest declares "follow latest stable VS Code" — no pinned version.
- **Resolution is a build artifact.** A resolver step in CI queries vendor APIs and writes a resolved manifest consumed by the build.
- **Generic template substitution.** Discovery URLs use `{param}` placeholders filled from manifest-supplied parameters.
- **`response_map` for vendor-agnostic field extraction.** The manifest specifies how to read the vendor's JSON response — no hardcoded field names.
- **Builds are internally consistent.** Resolution happens once per build cycle.

### What's in this PR

1. **RFC-0056** documenting the design
2. **Manifest types** in `bkt-common` (shared between `bkt` and `bkt-build`)
3. **Resolver** (`bkt-build resolve-vendor-artifacts`) — queries vendor feeds, writes resolved manifest
4. **Installer** (`bkt-build install-vendor-artifact`) — downloads resolved RPM, verifies SHA256, installs
5. **Containerfile generator** integration — parallel `vendor-*` build stages + RPM DB finalization
6. **CI workflow** — resolve step before Docker build + schema validation
7. **`manifests/vendor-artifacts.json`** with VS Code stable entry

### What's NOT in this PR

Migration of VS Code from `external-repos.json` to `vendor-artifacts.json`. That will be a separate small PR once this infrastructure lands. Currently both pipelines coexist — the vendor-artifacts stages are additive.

### Example manifest entry

```json
{
  "name": "code",
  "display_name": "Visual Studio Code",
  "kind": "rpm",
  "source": {
    "type": "vendor-feed",
    "url": "https://update.code.visualstudio.com/api/update/{platform}/{channel}/latest",
    "params": { "channel": "stable" },
    "platforms": { "x86_64": "linux-rpm-x64", "aarch64": "linux-rpm-arm64" },
    "response_map": {
      "url": "url",
      "version": "productVersion",
      "sha256": "sha256hash",
      "vendor_revision": "version"
    }
  },
  "layer_group": "independent"
}
```

### Commits

1. `docs:` RFC-0056
2. `feat:` manifest types and schema
3. `feat:` resolver and installer in bkt-build
4. `feat:` Containerfile generator integration (including RPM DB finalization)
5. `ci:` resolve step and schema validation